### PR TITLE
Request SSH PTY to enable nexus compatibility

### DIFF
--- a/lib/cisco/ssh.rb
+++ b/lib/cisco/ssh.rb
@@ -25,6 +25,7 @@ module Cisco
 			@results = []
 			@ssh = Net::SSH.start(*@sshargs)
 			@ssh.open_channel do |chan|
+				chan.request_pty
 				chan.send_channel_request("shell") do |ch, success|
 					if !success
 						abort "Could not open shell channel"


### PR DESCRIPTION
Testing shows that Nexus won't print a prompt unless you have a pty allocated, so this is necessary to work with Nexus devices.